### PR TITLE
Add browser packaging entry points

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "nes",
+  "homepage": "https://github.com/hapijs/nes",
+  "description": "WebSocket adapter plugin for hapi routes",
+  "main": "lib/client.js",
+  "keywords": [
+    "hapi"
+  ],
+  "moduleType": ["globals", "amd", "node"],
+  "license": "BSD-3-Clause",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/client');


### PR DESCRIPTION
Webpack and other commonjs aware systems can use `require(‘nes/client’)` to load the client library allowing for us to refactor the contents of lib as needed. Bower users may use the main definition to lookup the client path so `require(‘nes’)` may be used in client only code, in addition to `require(‘nes/client’)`.