### PR TITLE
Move callback validation to sender methods

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -182,8 +182,10 @@
             };
         }
 
+        var self = this;
+
         var request = {
-            id: ++this._ids,
+            id: 0,
             nes: 'request',
             method: options.method,
             path: options.path,
@@ -191,7 +193,20 @@
             payload: options.payload
         };
 
-        return this._send(request, callback);
+        return this._send(request, function (err, update) {
+
+            if (err) {
+                return callback(err);
+            }
+
+            if (update.nes !== 'response') {
+                self.onError(new Error('Received unexpected response type: ' + update.nes));
+            }
+            else {
+                var error = (update.statusCode >= 400 && update.statusCode <= 599 ? new Error(update.payload.message) : null);
+                callback(error, update.payload, update.statusCode, update.headers);
+            }
+        });
     };
 
     Client.prototype._send = function (request, callback) {
@@ -203,6 +218,8 @@
 
             return callback(new Error('Disconnected'));
         }
+
+        request.id = ++this._ids;
 
         stringify(request, function (err, encoded) {
 
@@ -224,13 +241,27 @@
 
     Client.prototype.authenticate = function (token, callback) {
 
+        var self = this;
+
         var request = {
-            id: ++this._ids,
+            id: 0,
             nes: 'auth',
             token: token
         };
 
-        return this._send(request, callback);
+        return this._send(request, function (err, update) {
+
+            if (err) {
+                return callback(err);
+            }
+
+            if (update.nes !== 'auth') {
+                self.onError(new Error('Received unexpected response type: ' + update.nes));
+            }
+            else {
+                callback(update.error ? new Error(update.error) : null);
+            }
+        });
     };
 
     Client.prototype._onMessage = function (message) {
@@ -252,23 +283,11 @@
             var callback = self._requests[update.id];
             delete self._requests[update.id];
             if (!callback) {
-                return self.onError(new Error('Received response for missing request'));
+                self.onError(new Error('Received response for missing request'));
             }
-
-            // Response
-
-            if (update.nes === 'response') {
-                var error = (update.statusCode >= 400 && update.statusCode <= 599 ? new Error(update.payload.message) : null);
-                return callback(error, update.payload, update.statusCode, update.headers);
+            else {
+                callback(null, update);
             }
-
-            // Authentication
-
-            if (update.nes === 'auth') {
-                return callback(update.error ? new Error(update.error) : null);
-            }
-
-            return self.onError(new Error('Received unknown response type: ' + update.nes));
         });
     };
 


### PR DESCRIPTION
This has two fold impact:
1. Detects potential corruption where a request packet is handled by the auth handler or vice versa.
2. Allows for users of onUnknownMessage to unsafely use _send while transitioning away from older protocols.