### PR TITLE
Allow for custom messages

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -198,6 +198,16 @@
         return this._send(request, callback);
     };
 
+    Client.prototype.message = function (data, callback) {
+
+        var request = {
+            nes: 'message',
+            data: data
+        };
+
+        return this._send(request, callback);
+    };
+
     Client.prototype._send = function (request, callback) {
 
         var self = this;
@@ -399,6 +409,12 @@
             if (update.nes === 'response') {
                 var error = (update.statusCode >= 400 && update.statusCode <= 599 ? new Error(update.payload.message) : null);
                 return callback(error, update.payload, update.statusCode, update.headers);
+            }
+
+            // Custom message
+
+            if (update.nes === 'message') {
+                return callback(update.error ? new Error(update.error) : null, update.data);
             }
 
             // Authentication

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ var internals = {
 
 internals.schema = Joi.object({
     onConnect: Joi.func(),                                  // function (ws) {}
+    onMessage: Joi.func(),                                  // function (message, reply) { reply(data); }
     onUnknownMessage: Joi.func(),                           // function (message, ws) { ws.send('string'); }
     auth: Joi.object({
         endpoint: Joi.string().required(),

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -69,7 +69,7 @@ internals.Listener.prototype._add = function (ws) {
     socket.authenticate(function () {
 
         if (self._settings.onConnect) {
-            self._settings.onConnect(ws);
+            self._settings.onConnect(socket);
         }
     });
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -262,7 +262,7 @@ internals.Socket.prototype._processMessage = function (request) {
         id: request.id
     };
 
-    self._listener._settings.onMessage(request.data, function (data) {
+    self._listener._settings.onMessage(self, request.data, function (data) {
 
         if (data instanceof Error) {
             response.error = data.message;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -94,6 +94,12 @@ internals.Socket.prototype.onMessage = function (message) {
             return self._processRequest(request);
         }
 
+        // Custom message request
+
+        if (request.nes === 'message') {
+            return self._processMessage(request);
+        }
+
         // Subscriptions
 
         if (request.nes === 'sub') {
@@ -238,6 +244,32 @@ internals.Socket.prototype._processRequest = function (request) {
             payload: res.result,
             headers: res.headers
         };
+
+        return self.send(response);
+    });
+};
+
+internals.Socket.prototype._processMessage = function (request) {
+
+    var self = this;
+
+    if (!self._listener._settings.onMessage) {
+        return self.send(Boom.badData('Custom messages are not supported'), { id: request.id });
+    }
+
+    var response = {
+        nes: 'message',
+        id: request.id
+    };
+
+    self._listener._settings.onMessage(request.data, function (data) {
+
+        if (data instanceof Error) {
+            response.error = data.message;
+        }
+        else {
+            response.data = data;
+        }
 
         return self.send(response);
     });

--- a/test/socket.js
+++ b/test/socket.js
@@ -498,4 +498,101 @@ describe('Socket', function () {
             });
         });
     });
+
+    describe('custom messages', function () {
+
+        it('calls onMessage callback', function (done) {
+
+            var onMessage = function (message, reply) {
+
+                expect(message).to.equal('winning');
+                reply('hello');
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.register({ register: Nes, options: { onMessage: onMessage } }, function (err) {
+
+                expect(err).to.not.exist();
+
+                server.start(function (err) {
+
+                    var client = new Nes.Client('http://localhost:' + server.info.port);
+                    client.connect(function () {
+
+                        client.message('winning', function (err, response) {
+
+                            expect(err).to.not.exist();
+                            expect(response).to.equal('hello');
+                            client.disconnect();
+                            server.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+
+        it('it sends errors from callback', function (done) {
+
+            var client;
+
+            var onMessage = function (message, reply) {
+
+                expect(message).to.equal('winning');
+                reply(new Error('failed'));
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.register({ register: Nes, options: { onMessage: onMessage } }, function (err) {
+
+                expect(err).to.not.exist();
+
+                server.start(function (err) {
+
+                    client = new Nes.Client('http://localhost:' + server.info.port);
+                    client.connect(function () {
+
+                        client.message('winning', function (err, response) {
+
+                            expect(err).to.match(/failed/);
+                            expect(response).to.not.exist();
+                            client.disconnect();
+                            server.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+
+        it('errors if missing onMessage callback', function (done) {
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.register({ register: Nes, options: { } }, function (err) {
+
+                expect(err).to.not.exist();
+
+                server.start(function (err) {
+
+                    var client = new Nes.Client('http://localhost:' + server.info.port);
+                    client.connect(function () {
+
+                        client.message('winning', function (err, response) {
+
+                            expect(err).to.match(/Custom messages are not supported/);
+                            expect(response).to.deep.equal({
+                                statusCode: 422,
+                                error: 'Unprocessable Entity',
+                                message: 'Custom messages are not supported'
+                            });
+
+                            client.disconnect();
+                            server.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
 });

--- a/test/socket.js
+++ b/test/socket.js
@@ -503,7 +503,7 @@ describe('Socket', function () {
 
         it('calls onMessage callback', function (done) {
 
-            var onMessage = function (message, reply) {
+            var onMessage = function (socket, message, reply) {
 
                 expect(message).to.equal('winning');
                 reply('hello');
@@ -536,7 +536,7 @@ describe('Socket', function () {
 
             var client;
 
-            var onMessage = function (message, reply) {
+            var onMessage = function (socket, message, reply) {
 
                 expect(message).to.equal('winning');
                 reply(new Error('failed'));


### PR DESCRIPTION
This allows for the client to send custom messages to the server using the `client.message` API and the server to respond using the `onMessage` plugin callback option.

These are akin to raw access to the channel and do not provide any higher-level hapi features such as auth, request-based logging, etc.