### PR TITLE
Decouple event creation from transmission

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,0 +1,33 @@
+// Load modules
+var Util = require('util');
+var EventEmitter = require('events').EventEmitter;
+
+// Declare internals
+
+var internals = {};
+
+exports = module.exports = internals.Adapter = function (listener, settings) {
+
+    EventEmitter.call(this);
+
+    this._listener = listener;
+    this._settings = settings;
+};
+
+Util.inherits(internals.Adapter, EventEmitter);
+
+
+internals.Adapter.prototype.broadcast = function (update) {
+
+    this.emit('broadcast', update);
+};
+
+internals.Adapter.prototype.publish = function (path, message) {
+
+    this.emit('publish', path, message);
+};
+
+internals.Adapter.prototype.stop = function () {
+
+  // no-op
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ var Iron = require('iron');
 var Joi = require('joi');
 var Client = require('./client');
 var Listener = require('./listener');
+var Adapter = require('./adapter');
+var EventEmitter = require('events').EventEmitter;
 
 
 // Declare internals
@@ -26,6 +28,7 @@ var internals = {
 
 
 internals.schema = Joi.object({
+    adapter: Joi.object().type(EventEmitter),
     onConnect: Joi.func(),                                  // function (ws) {}
     onMessage: Joi.func(),                                  // function (message, reply) { reply(data); }
     auth: Joi.object({
@@ -57,6 +60,13 @@ internals.schema = Joi.object({
 exports.register = function (server, options, next) {
 
     var settings = Hoek.applyToDefaults(internals.defaults, options);
+
+    if (!options.adapter) {
+        settings.adapter = new Adapter();
+    } else {
+        settings.adapter = options.adapter;
+    }
+
     Joi.assert(settings, internals.schema, 'Invalid nes configuration');
 
     // Authentication endpoint
@@ -80,7 +90,20 @@ exports.register = function (server, options, next) {
             listners[l]._close();
         }
 
+        settings.adapter.stop();
+
         return extNext();
+    });
+
+    // Set up adapter
+
+    server.plugins.nes = {
+        _adapter : settings.adapter
+    };
+
+    server.plugins.nes._adapter.on('error', function (err) {
+
+        server.log(['nes', 'adapter', 'error'], err);
     });
 
     // Decorate server
@@ -98,6 +121,8 @@ exports.register.attributes = {
 
 
 exports.Client = Client.Client;
+
+exports.Adapter = Adapter;
 
 
 internals.auth = function (server, settings) {

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -41,6 +41,18 @@ exports = module.exports = internals.Listener = function (connection, settings) 
     connection.plugins.nes = {
         _listener: this
     };
+
+    // Listen to adapter
+
+    this._settings.adapter.on('broadcast', function (update) {
+
+        self._broadcast(update);
+    });
+
+    this._settings.adapter.on('publish', function (path, message) {
+
+        self._publish(path, message);
+    });
 };
 
 
@@ -100,13 +112,7 @@ internals.Listener.broadcast = function (message) {
         message: message
     };
 
-    var connections = this.connections;
-    for (var i = 0, il = connections.length; i < il; ++i) {
-        var connection = connections[i];
-        if (connection.plugins.nes) {
-            connection.plugins.nes._listener._broadcast(update);
-        }
-    }
+    this.plugins.nes._adapter.broadcast(update);
 };
 
 
@@ -191,13 +197,7 @@ internals.Listener.publish = function (path, update) {
         message: update
     };
 
-    var connections = this.connections;
-    for (var i = 0, il = connections.length; i < il; ++i) {
-        var connection = connections[i];
-        if (connection.plugins.nes) {
-            connection.plugins.nes._listener._publish(path, message);
-        }
-    }
+    this.plugins.nes._adapter.publish(path, message);
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,48 @@ describe('register()', function () {
         });
     });
 
+    it('accepts a custom adapter', function (done) {
+
+        var server = new Hapi.Server();
+        var adapter = new Nes.Adapter();
+        server.connection();
+        server.register({ register: Nes, options: { adapter: adapter, auth: false } }, function (err) {
+
+            expect(err).to.not.exist();
+
+            server.start(function (err) {
+
+                expect(server.plugins.nes._adapter).to.equal(adapter);
+                server.stop(done);
+            });
+        });
+    });
+
+    it('logs adapter errors', function (done) {
+
+        var server = new Hapi.Server();
+        var adapter = new Nes.Adapter();
+        server.connection();
+        server.register({ register: Nes, options: { adapter: adapter, auth: false } }, function (err) {
+
+            expect(err).to.not.exist();
+
+            server.on('log', function (event, tags) {
+
+                expect(event.data.message).to.equal('Hello');
+                server.stop(done);
+            });
+
+            server.start(function (err) {
+
+                expect(err).to.not.exist();
+                expect(server.plugins.nes._adapter).to.equal(adapter);
+
+                adapter.emit('error', new Error('Hello'));
+            });
+        });
+    });
+
     it('calls onConnect callback', function (done) {
 
         var client;


### PR DESCRIPTION
This PR introduces the idea of an adapter pattern similar to [socket.io-redis](https://github.com/socketio/socket.io-redis). The built-in adapter provides a very simple in-process adapter which is only intended to maintain the current functionality.

Here is an example of how I imagine a Redis adapter might be implemented (it needs some work, but is functional enough to demostrate the idea): https://gist.github.com/bjyoungblood/11b346293f5ead88ce7a

----

#### Notes

Currently, the Joi validation only checks that an Adapter passed by config is an instance of an EventEmitter. Would it make sense to require Adapters to extend the built-in Adapter?