### PR TITLE
Added browser attribute for client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "repository": "git://github.com/hapijs/nes",
   "main": "lib/index.js",
+  "browser": "lib/client.js",
   "keywords": [
     "hapi",
     "plugin",


### PR DESCRIPTION
I tested this with browserify and it worked to load just the client with `require('nes')`. If your modular loader doesnt support the `browser` attribute then you will need to still load with `require('nes/client')`.