### PR TITLE
Implement per-subscription lifecycle

### DIFF
--- a/API.md
+++ b/API.md
@@ -146,6 +146,14 @@ Declares a subscription path client can subscribe to where:
                 - `'user'`
                 - `'app'`
                 - `'any'`
+    - `onSubscribe` - Callback called when a client subscribes to this subscription endpoint.
+      `function(socket, path)`
+        - `socket` - the [`Socket`](#socket) object of the incoming connection.
+        - `path` - the path the client subscribed to
+    - `onUnsubscribe` - Callback called when a client unsubscribes from this subscription endpoint.
+      `function(socket, path)`.
+        - `socket` - the [`Socket`](#socket) object of the incoming connection.
+        - `path` - Path of the unsubscribed route.
 
 ### `server.publish(path, message)`
 

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -182,6 +182,8 @@ internals.Listener.prototype._broadcast = function (update) {
 
 internals.subSchema = Joi.object({
     filter: Joi.func(),                                             // function (path, update, options, next), where options: { credentials, params }
+    onSubscribe: Joi.func(),                                        // function (socket)
+    onUnsubscribe: Joi.func(),                                      // function (socket)
     auth: Joi.object({
         mode: Joi.string().valid('required', 'optional'),
         scope: Joi.array().items(Joi.string()).single().min(1),
@@ -226,7 +228,7 @@ internals.Listener.subscription = function (path, options) {
     };
 
     var config = {
-        subscribers: new internals.Subscribers(),
+        subscribers: new internals.Subscribers(settings),
         filter: settings.filter,
         auth: auth
     };
@@ -399,8 +401,10 @@ internals.Sockets.prototype.length = function () {
 
 // Subscribers manager
 
-internals.Subscribers = function () {
+internals.Subscribers = function (options) {
 
+    this._onSubscribe = options.onSubscribe;
+    this._onUnsubscribe = options.onUnsubscribe;
     this._items = {};
 };
 
@@ -414,18 +418,28 @@ internals.Subscribers.prototype.add = function (socket, path) {
     else {
         this._items[socket.id] = { socket: socket, paths: [path] };
     }
+
+    if (this._onSubscribe) {
+        this._onSubscribe(socket, path);
+    }
 };
 
 
 internals.Subscribers.prototype.remove = function (socket, path) {
 
-    if (!path) {
-        delete this._items[socket.id];
+    var item = this._items[socket.id];
+    if (!item) {
         return;
     }
 
-    var item = this._items[socket.id];
-    if (!item) {
+    if (!path) {
+        if (this._onUnsubscribe) {
+            for (var i = 0, il = item.paths.length; i < il; ++i) {
+                this._onUnsubscribe(socket, item.paths[i]);
+            }
+        }
+
+        delete this._items[socket.id];
         return;
     }
 
@@ -436,10 +450,14 @@ internals.Subscribers.prototype.remove = function (socket, path) {
 
     if (item.paths.length === 1) {
         delete this._items[socket.id];
-        return;
+    }
+    else {
+        item.paths.splice(pos, 1);
     }
 
-    item.paths.splice(pos, 1);
+    if (this._onUnsubscribe) {
+        this._onUnsubscribe(socket, path);
+    }
 };
 
 


### PR DESCRIPTION
Allows setup and teardown logic for a given subscription endpoint.

Fixes #57