### PR TITLE
Use internal auth endpoint id for lookup

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -198,7 +198,8 @@ internals.Socket.prototype._processHello = function (request) {
 
     var config = this._listener._settings.auth;
     if (config.type === 'direct') {
-        this._listener._connection.inject({ url: config.endpoint, method: 'auth', headers: request.auth.headers, allowInternals: true }, function (res) {
+        var route = this._listener._connection.lookup(config.id);
+        this._listener._connection.inject({ url: route.path, method: 'auth', headers: request.auth.headers, allowInternals: true }, function (res) {
 
             if (res.statusCode !== 200) {
                 return self._error(Boom.unauthorized(res.result.message), request);


### PR DESCRIPTION
This avoids issues when using route prefixes when registering the plugin.

Fixes #66