### PR TITLE
Fix illegal invocation error when using default onError handler.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -86,7 +86,10 @@
 
         // Events
 
-        this.onError = console.error;               // General error callback (only when an error cannot be associated with a request)
+        this.onError = (err) => {                   // General error callback (only when an error cannot be associated with a request)
+
+            console.error(err);
+        };
         this.onConnect = ignore;                    // Called whenever a connection is established
         this.onDisconnect = ignore;                 // Called whenever a connection is lost: function(willReconnect)
         this.onUpdate = ignore;


### PR DESCRIPTION
console.error does not have proper `this` context when being called directly