### PR TITLE
Fix UMD global handling

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -26,7 +26,7 @@
 
     // $lab:coverage:on$
 
-})(this, () => {
+})(/* $lab:coverage:off$ */ typeof window !== 'undefined' ? window : global /* $lab:coverage:on$ */, () => {
 
     // Utilities
 


### PR DESCRIPTION
Babel replaces this with undefined under strict mode, breaking the global declaration for the UMD module. Unclear on if this changed recently (I doubt) or if we never tested this under globals mode before.

Fixes #105