### PR TITLE
Verify request Origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,8 @@ internals.schema = Joi.object({
         timeout: Joi.number().integer().min(1).less(Joi.ref('interval')).required()
     })
         .allow(false),
-    maxConnections: Joi.number().integer().min(1).allow(false)
+    maxConnections: Joi.number().integer().min(1).allow(false),
+    origin: Joi.array().items(Joi.string())
 });
 
 

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -35,7 +35,11 @@ exports = module.exports = internals.Listener = function (connection, settings) 
 
     // WebSocket listener
 
-    this._wss = new Ws.Server({ server: connection.listener });
+    const serverOptions = { server: connection.listener };
+    if (settings.origin) {
+        serverOptions.verifyClient = (info) => settings.origin.indexOf(info.origin) >= 0;
+    }
+    this._wss = new Ws.Server(serverOptions);
 
     this._wss.on('connection', (ws) => {
 

--- a/test/listener.js
+++ b/test/listener.js
@@ -116,6 +116,50 @@ describe('Listener', () => {
         });
     });
 
+    it('rejects unknown origin', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register({ register: Nes, options: { auth: false, origin: ['http://localhost:12345'] } }, (err) => {
+
+            expect(err).to.not.exist();
+
+            server.start((err) => {
+
+                expect(err).to.not.exist();
+                const client = new Nes.Client('http://localhost:' + server.info.port);
+                client.connect((err) => {
+
+                    expect(err).to.exist();
+                    client.disconnect();
+                    server.stop(done);
+                });
+            });
+        });
+    });
+
+    it('accepts known origin', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register({ register: Nes, options: { auth: false, origin: ['http://localhost:12345'] } }, (err) => {
+
+            expect(err).to.not.exist();
+
+            server.start((err) => {
+
+                expect(err).to.not.exist();
+                const client = new Nes.Client('http://localhost:' + server.info.port, { ws: { origin: 'http://localhost:12345' } });
+                client.connect((err) => {
+
+                    expect(err).not.to.exist();
+                    client.disconnect();
+                    server.stop(done);
+                });
+            });
+        });
+    });
+
     describe('_beat()', () => {
 
         it('disconnects client after timeout', (done) => {


### PR DESCRIPTION
Adds support for a list of origins that are allowed to establish the connection - similar to Hapi's `cors.origin`.