### PR TITLE
Handle undefined payloads from server in client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -73,8 +73,8 @@
 
     const NesError = function (err, type) {
 
-        if (typeof err === 'string') {
-            err = new Error(err);
+        if (!err || typeof err === 'string') {
+            err = new Error(err || 'Unknown error');
         }
 
         err.type = type;


### PR DESCRIPTION
NesError(error, type) can be called with the `error` argument undefined.

This can happen if `update.payload.message || update.payload.error` are both undefined here:

https://github.com/davidjamesstone/nes/blob/master/lib/client.js#L616

This guards against it.