### PR TITLE
Do not replace message for all sockets with override from filter

### DIFF
--- a/lib/listener.js
+++ b/lib/listener.js
@@ -280,7 +280,7 @@ internals.Listener.publish = function (path, update, options) {
 };
 
 
-internals.Listener.prototype._publish = function (path, update, options) {
+internals.Listener.prototype._publish = function (path, _update, options) {
 
     if (this._stopped) {
         return;
@@ -292,6 +292,8 @@ internals.Listener.prototype._publish = function (path, update, options) {
     }
 
     const each = async (socket) => {       // Filter on path if has parameters
+
+        let update = _update;
 
         if (route.filter) {
             try {


### PR DESCRIPTION
This ensures that an override message does not affect the message sent to other connected sockets. First though it would be great if @hueniverse can confirm this is indeed a bug and not a feature.

Closes #212 
