### PR TITLE
Fix request.auth.credentials for token auth

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -353,7 +353,9 @@ internals.Socket.prototype._processHello = async function (request) {
         }
         else {
             try {
-                auth.credentials = await Iron.unseal(request.auth, config.password, config.iron || Iron.defaults);
+                const { credentials, artifacts } = await Iron.unseal(request.auth, config.password, config.iron || Iron.defaults);
+                auth.credentials = credentials;
+                auth.artifacts = artifacts;
             }
             catch (err) {
                 throw Boom.unauthorized('Invalid token');


### PR DESCRIPTION
When the Iron token is unsealed we're expecting it to be a value equal to `credentials` however it is an object like `{ credentials, artifacts }`, this means we're causing `request.auth.credentials` to have structure `{ credentials: { credentials: {} } }`.

Although this is a bug, it's been around for so long that people have likely put workarounds in place and I don't want to break their apps so I think it has to be another breaking change. Which sucks a bit because I just released 8.0.0 yesterday.

Closes #176 