### PR TITLE
Update README authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ const start = async () => {
         return { isValid, credentials };
     };
 
-    server.auth.strategy('simple', 'basic', 'required', { validate });
+    server.auth.strategy('simple', 'basic', { validate });
 
     // Configure route with authentication
 


### PR DESCRIPTION
Hi,
in the example on the README there was an extra parameter ('required') when showing how to register the [`hapi-auth-basic`] plugin.

Leaving that parameter there would result in an error (`AssertionError [ERR_ASSERTION]: options must be an object`).