### PR TITLE
Document minAuthVerifyInterval and make it less restrictive

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,4 +1,4 @@
-# 9.0.x API Reference
+# 9.1.x API Reference
 
 - [Registration](#registration)
 - [Server](#server)

--- a/API.md
+++ b/API.md
@@ -111,6 +111,10 @@ method. The plugin accepts the following optional registration options:
           Defaults to `5000` (5 seconds).
         - `maxConnectionsPerUser` - if specified, limits authenticated users to a maximum number of
           client connections. Requires the `index` option enabled. Defaults to `false`.
+        - `minAuthVerifyInterval` - if specified, waits at least the specificed number of milliseconds
+          between calls to [`await server.auth.verify()`](https://hapijs.com/api#-await-serverauthverifyrequest) 
+          to check if credentials are still valid. Cannot be shorter than `heartbeat.interval`. 
+          Defaults to `heartbeat.interval`.
 - `headers` - an optional array of header field names to include in server responses to the client.
   If set to `'*'` (without an array), allows all headers. Defaults to `null` (no headers).
 - `payload` - optional message payload settings where:

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,8 +23,7 @@ const internals = {
             path: '/',
             index: false,
             timeout: 5000,                                  // 5 seconds
-            maxConnectionsPerUser: false,
-            minAuthVerifyInterval: 15000
+            maxConnectionsPerUser: false
         },
         headers: null,
         payload: {
@@ -83,7 +82,11 @@ internals.schema = Joi.object({
     maxConnections: Joi.number().integer().min(1).allow(false),
     origin: Joi.array().items(Joi.string()).single().min(1)
 })
-    .assert('auth.minAuthVerifyInterval', Joi.number().min(Joi.ref('heartbeat.interval')));
+    .assert('auth.minAuthVerifyInterval', Joi.when('heartbeat', {
+        is: false,
+        then: Joi.number().min(1),
+        otherwise: Joi.number().min(Joi.ref('heartbeat.interval'))
+    }));
 
 
 exports.plugin = {
@@ -94,11 +97,16 @@ exports.plugin = {
     register: function (server, options) {
 
         const settings = Hoek.applyToDefaults(internals.defaults, options);
-        Joi.assert(settings, internals.schema, 'Invalid nes configuration');
 
         if (Array.isArray(settings.headers)) {
             settings.headers = settings.headers.map((field) => field.toLowerCase());
         }
+
+        if (settings.heartbeat && settings.auth && settings.auth.minAuthVerifyInterval === undefined) {
+            settings.auth.minAuthVerifyInterval = settings.heartbeat.interval;
+        }
+
+        Joi.assert(settings, internals.schema, 'Invalid nes configuration');
 
         // Authentication endpoint
 


### PR DESCRIPTION
* Changed the default `minAuthVerifyInterval` value to be the same as configured `heartbeat.interval`, rather than the hardcoded 15s - otherwise when `heartbeat.interval` is configured to be longer than that, this becomes a breaking change.
* When `heartbeat` is disabled, no throttling applies (not sure how people use it, but this might mean that after all - `_verifyAuth()` should be called on outgoing messages too).
