### PR TITLE
Passing remoteAddress when connect with auth

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -528,7 +528,7 @@ internals.Socket.prototype._authenticate = async function (request) {
         const config = this._listener._settings.auth;
         if (config.type === 'direct') {
             const route = this.server.lookup(config.id);
-            const res = await this.server.inject({ url: route.path, method: 'auth', headers: request.auth.headers, allowInternals: true, validate: false });
+            const res = await this.server.inject({ url: route.path, method: 'auth', headers: request.auth.headers, remoteAddress: this.info.remoteAddress, allowInternals: true, validate: false });
             if (res.statusCode !== 200) {
                 throw Boom.unauthorized(res.result.message);
             }


### PR DESCRIPTION
Passing remoteAddress when connect with auth.
In my case, validate auth strategy need checking client IP.