### PR TITLE
Add ability to revoke a socket ignoring if it is already closed

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,7 +15,7 @@
     - [`socket.disconnect()`](#socketdisconnect)
     - [`await socket.send(message)`](#await-socketsendmessage)
     - [`await socket.publish(path, message)`](#await-socketpublishpath-message)
-    - [`await socket.revoke(path, message)`](#await-socketrevokepath-message)
+    - [`await socket.revoke(path, message, throwIfClosed)`](#await-socketrevokepath-message)
 - [Request](#request)
     - [`request.socket`](#requestsocket)
 - [Client](#client)
@@ -112,8 +112,8 @@ method. The plugin accepts the following optional registration options:
         - `maxConnectionsPerUser` - if specified, limits authenticated users to a maximum number of
           client connections. Requires the `index` option enabled. Defaults to `false`.
         - `minAuthVerifyInterval` - if specified, waits at least the specificed number of milliseconds
-          between calls to [`await server.auth.verify()`](https://hapijs.com/api#-await-serverauthverifyrequest) 
-          to check if credentials are still valid. Cannot be shorter than `heartbeat.interval`. 
+          between calls to [`await server.auth.verify()`](https://hapijs.com/api#-await-serverauthverifyrequest)
+          to check if credentials are still valid. Cannot be shorter than `heartbeat.interval`.
           Defaults to `heartbeat.interval` or `15000` if `heartbeat` is disabled.
 - `headers` - an optional array of header field names to include in server responses to the client.
   If set to `'*'` (without an array), allows all headers. Defaults to `null` (no headers).
@@ -289,6 +289,8 @@ Revokes a subscription and optionally includes a last update where:
 - `message` - an optional last subscription update sent to the client. Can be any type which can be
   safely converted to string using `JSON.stringify()`. Pass `null` to revoke the subscription without
   sending a last update.
+- `throwIfClosed` - flag indicating what should be done if a underlying websocket has been closed.
+  defaults to `true`.
 
 ## Request
 
@@ -437,21 +439,21 @@ the client is configured to automatically reconnect, where:
 
 Returns `true` if reconnection is enabled, otherwise `false` (in which case the method was ignored).
 
-Note: this will not update the credentials on the server - 
+Note: this will not update the credentials on the server -
 use [`client.reauthenticate()`](#await-clientreauthenticateauth).
 
 ### `await client.reauthenticate(auth)`
 
-Will issue the `reauth` message to the server with updated `auth` details and also 
-[override the reconnection information](#clientoverridereconnectionauthauth), if reconnection is enabled. 
-The server will respond with an error and drop the connection in case the new `auth` credentials are 
+Will issue the `reauth` message to the server with updated `auth` details and also
+[override the reconnection information](#clientoverridereconnectionauthauth), if reconnection is enabled.
+The server will respond with an error and drop the connection in case the new `auth` credentials are
 invalid.
 
 Rejects with `Error` if the request failed.
 
 Resolves with `true` if the request succeeds.
 
-Note: when authentication has a limited lifetime, `reauthenticate()` should be called early enough to avoid 
+Note: when authentication has a limited lifetime, `reauthenticate()` should be called early enough to avoid
 the server dropping the connection.
 
 ### Errors

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -87,7 +87,7 @@ internals.Socket.prototype.publish = function (path, update) {
 };
 
 
-internals.Socket.prototype.revoke = async function (path, update) {
+internals.Socket.prototype.revoke = async function (path, update, throwIfClosed = true) {
 
     await this._unsubscribe(path);
 
@@ -100,15 +100,24 @@ internals.Socket.prototype.revoke = async function (path, update) {
         message.message = update;
     }
 
+    if (!throwIfClosed &&
+        !this.isOpen()) {
+        return Promise.resolve();
+    }
+
     return this._send(message);
 };
 
+internals.Socket.prototype.isOpen = function () {
+
+    return this._ws.readyState === 1;
+};
 
 internals.Socket.prototype._send = function (message, options) {
 
     options = options || {};
 
-    if (this._ws.readyState !== 1) {                                // Open
+    if (!this.isOpen()) {                                           // Open
         return Promise.reject(Boom.internal('Socket not open'));
     }
 

--- a/test/client.js
+++ b/test/client.js
@@ -931,7 +931,8 @@ describe('Client', () => {
             const a = { b: 1 };
             a.a = a;
 
-            const err = await expect(client.request({ method: 'POST', path: '/', payload: a })).to.reject('Converting circular structure to JSON');
+            const err = await expect(client.request({ method: 'POST', path: '/', payload: a })).to.reject();
+            expect(err.message).to.startWith('Converting circular structure to JSON');
             expect(err.type).to.equal('user');
             expect(err.isNes).to.equal(true);
             client.disconnect();

--- a/test/client.js
+++ b/test/client.js
@@ -1672,7 +1672,7 @@ describe('Client', () => {
             const team = new Teamwork();
             server.eachSocket(async (socket) => {
 
-                await socket.revoke('/', null);
+                await socket.revoke('/', null, false);
                 await Hoek.wait(50);
 
                 expect(client.subscriptions()).to.equal([]);
@@ -1682,6 +1682,83 @@ describe('Client', () => {
 
             await team.work;
             client.disconnect();
+            await server.stop();
+        });
+
+        it('handles revocation on closed websocket when throwIfClosed is false', async () => {
+
+            const server = Hapi.server();
+            await server.register({ plugin: Nes, options: { auth: false } });
+
+            const onUnsubscribe = new Teamwork();
+            server.subscription('/', { onUnsubscribe: () => onUnsubscribe.work });
+
+            await server.start();
+            const client = new Nes.Client('http://localhost:' + server.info.port);
+            await client.connect();
+
+            let updated = false;
+            const handler = (update, flags) => {
+
+                updated = true;
+            };
+
+            await client.subscribe('/', handler);
+            expect(client.subscriptions()).to.equal(['/']);
+
+            const team = new Teamwork();
+            client.disconnect();
+            server.eachSocket(async (socket) => {
+
+                await socket.revoke('/', null, false);
+                await Hoek.wait(50);
+                team.attend();
+            });
+
+            await Hoek.wait(50);
+            onUnsubscribe.attend();
+
+            await team.work;
+            expect(updated).to.be.false();
+
+            await server.stop();
+        });
+
+        it('throws by default if revoking closed web socket', async () => {
+
+            const server = Hapi.server();
+            await server.register({ plugin: Nes, options: { auth: false } });
+
+            const onUnsubscribe = new Teamwork();
+            server.subscription('/', { onUnsubscribe: () => onUnsubscribe.work });
+
+            await server.start();
+            const client = new Nes.Client('http://localhost:' + server.info.port);
+            await client.connect();
+
+            let updated = false;
+            const handler = (update, flags) => {
+
+                updated = true;
+            };
+
+            await client.subscribe('/', handler);
+            expect(client.subscriptions()).to.equal(['/']);
+
+            const team = new Teamwork();
+            client.disconnect();
+            server.eachSocket((socket) => {
+
+                expect(socket.revoke('/', null)).to.reject('Socket not open');
+                team.attend();
+            });
+
+            await Hoek.wait(50);
+            onUnsubscribe.attend();
+
+            await team.work;
+            expect(updated).to.be.false();
+
             await server.stop();
         });
 


### PR DESCRIPTION
In cases where there is an `onUnsubscribe` handler registered it is possible that `revoke` can be called on a socket that has since been closed. This results in an error being thrown.

To prevent having to try/catch and explicitly test for `nes`'s internal `Socket not open` error this new flag `throwIfClosed` allows the user to signal their intent to "fire and forget".

Because `revoke` is async internally it is not possible to catch this with certainty prior to making the `revoke` call.

The added tests demonstrate the issue we are seeing in production.