### PR TITLE
 Properly set isAuthenticated from the auth object's optional status key.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -590,7 +590,7 @@ internals.Socket.prototype._authByCookie = async function () {
 
 internals.Socket.prototype._setCredentials = function (auth) {
 
-    this.auth.isAuthenticated = true;
+    this.auth.isAuthenticated = auth.status !== 'unauthenticated';
     this.auth.credentials = auth.credentials;
     this.auth.artifacts = auth.artifacts;
     this.auth.strategy = auth.strategy;


### PR DESCRIPTION
This is a follow up from https://github.com/hapijs/nes/pull/274.

The unit test in the first commit fails without the second commit.