### PR TITLE
feat: pass on cookies to auth route

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -545,6 +545,7 @@ internals.Socket.prototype._authenticate = async function (request) {
             const route = this.server.lookup(config.id);
             request.auth.headers = request.auth.headers || {};
             request.auth.headers['x-forwarded-for'] = this.info['x-forwarded-for'];
+            request.auth.headers['cookie'] = this._cookies;
             const res = await this.server.inject({ url: route.path, method: 'auth', headers: request.auth.headers, remoteAddress: this.info.remoteAddress, allowInternals: true, validate: false });
             if (res.statusCode !== 200) {
                 throw Boom.unauthorized(res.result.message);


### PR DESCRIPTION
My use case is that I have a cookie where I store the device id. I would like to access the device id in the `authenticate` method eventually but currently there is no way to access the cookies. 

If you are fine, I will create a test for it.