### PR TITLE
Prevent beat timeout from disconnecting newly connecting sockets

### DIFF
--- a/lib/listener.js
+++ b/lib/listener.js
@@ -144,7 +144,8 @@ internals.Listener.prototype._beat = function () {
 
             this._sockets._forEach((socket) => {
 
-                if (!socket._active()) {
+                if (!socket._active() &&
+                    socket._created + this._settings.heartbeat.timeout - 1 < Date.now()) {
                     socket.disconnect();
                     return;
                 }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -25,6 +25,7 @@ exports = module.exports = internals.Socket = function (ws, req, listener) {
     this._packets = [];
     this._sending = false;
     this._removed = new Teamwork.Team();
+    this._created = Date.now();
 
     this.server = this._listener._server;
     this.id = this._listener._generateId();


### PR DESCRIPTION
## Issue

Occasionally `client.connect()` errors with `Request failed - server disconnected` milliseconds after initiating the connection.

## Root cause

This error occurs because for a short lived time a socket is established on the server but the `nes` "hello" handshake message has not been processed so `socket._active()` will return `false` due to the fact that `this._pinged` is false. Once the "hello" message is processed the socket is correctly identified as active.

If the beat timeout occurs between the websocket being added to to the sockets collection but before the "hello" is processed the beat timeout logic will disconnect the socket.

## Proposed fix

The proposed fix is to allow a grace period in which newly created sockets are not disconnected by the beat timeout.

## Testing

Being a race condition it is difficult to test but the unit test added will fail repeatedly if my logic is removed.