### PR TITLE
fix: pass remoteAddress when injecting request

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -437,7 +437,8 @@ internals.Socket.prototype._processRequest = async function (request) {
             nes: {
                 socket: this
             }
-        }
+        },
+        remoteAddress: this.info.remoteAddress
     };
 
     const res = await this.server.inject(shot);


### PR DESCRIPTION
Resolves #305 

`remoteAddress` was not passed to `server.inject()` resulting in always getting `127.0.0.1` in `request.info.remoteAddress` in the route handler.