### PR TITLE
Fix client reconnect retry attempts

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -392,6 +392,10 @@
             return;
         }
 
+        if (this._reconnectionTimer) {
+            return;
+        }
+
         if (reconnection.retries < 1) {
             return this._disconnect(ignore, true);      // Clear _reconnection state
         }

--- a/test/client.js
+++ b/test/client.js
@@ -893,7 +893,7 @@ describe('Client', () => {
         it('utilizes every connection retry attempt', async () => {
 
             const team = new Teamwork.Team();
-            const client = new Nes.Client('http://doesnotexist');
+            const client = new Nes.Client('http://0');
 
             let errorCount = 0;
             client.onError = (err) => {

--- a/test/client.js
+++ b/test/client.js
@@ -890,6 +890,35 @@ describe('Client', () => {
             await server.stop();
         });
 
+        it('utilizes every connection retry attempt', async () => {
+
+            const team = new Teamwork.Team();
+            const client = new Nes.Client('http://doesnotexist');
+
+            let errorCount = 0;
+            client.onError = (err) => {
+
+                errorCount++;
+
+                if (err.message === 'Socket error') {
+                    // This is the final error message once retry attempts have run-out
+                    team.attend();
+                }
+            };
+
+            try {
+                await client.connect({ delay: 1, retries: 5 });
+            }
+            catch {}
+
+            await team.work;
+
+            // Should see name number of errors as allowed retry attempts
+            expect(errorCount).to.equal(5);
+
+            client.disconnect();
+        });
+
         it('aborts reconnect if disconnect is called in between attempts', async () => {
 
             const server = Hapi.server();


### PR DESCRIPTION
Builds on and replaces #318, adding a failing test.  #318 contains a fix for reconnect retry attempts getting used-up too quickly due to some duplicated calls to `_reconnect()`.