### PR TITLE
Declare correct `ws` options type

### DIFF
--- a/lib/client.d.ts
+++ b/lib/client.d.ts
@@ -1,3 +1,6 @@
+import type { ClientRequestArgs } from "http";
+import type { ClientOptions } from "ws";
+
 // Same as exported type in @hapi/hapi v20
 type HTTP_METHODS = 'ACL' | 'BIND' | 'CHECKOUT' | 'CONNECT' | 'COPY' | 'DELETE' | 'GET' | 'HEAD' | 'LINK' | 'LOCK' |
     'M-SEARCH' | 'MERGE' | 'MKACTIVITY' | 'MKCALENDAR' | 'MKCOL' | 'MOVE' | 'NOTIFY' | 'OPTIONS' | 'PATCH' | 'POST' |
@@ -173,7 +176,7 @@ export class Client {
     constructor(
         url: `ws://${string}` | `wss://${string}`,
         options?: {
-            ws?: string | string[];
+            ws?: ClientOptions | ClientRequestArgs;
             timeout?: number | boolean;
         });
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@hapi/iron": "^7.0.1",
     "@hapi/teamwork": "^6.0.0",
     "@hapi/validate": "^2.0.1",
+    "@types/ws": "^8.5.13",
     "ws": "^8.17.1"
   },
   "devDependencies": {

--- a/test/types/client.ts
+++ b/test/types/client.ts
@@ -7,7 +7,13 @@ import { Client } from '../../lib/client';
 
 const init = () => {
 
-    const client = new Client('ws://localhost');
+    const client = new Client('ws://localhost', {
+        ws: { // optional
+            origin: 'http://localhost:12345',
+            maxPayload: 1000,
+            headers: { cookie: 'xnes=123' }
+        }
+    });
 
     client.connect()
 


### PR DESCRIPTION
The original `string | string[]` seems to have been a confusion because the `ws` package client takes 3 arguments, of which the middle one (`protocols`) is the `string | string[]`, but it is optional. When it is left out - it becomes the `options` object instead: https://github.com/websockets/ws/blob/c798dd4ee20efb2d7591b5659839ad05cdb3eb70/lib/websocket.js#L80

The type information is covered in jsdoc: https://github.com/websockets/ws/blob/c798dd4ee20efb2d7591b5659839ad05cdb3eb70/lib/websocket.js#L627

A more complete typing information is exposed by `@types/ws`, though.

Closes #337.